### PR TITLE
Implement filling up to a certain point

### DIFF
--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -55,7 +55,9 @@ def sync_batch(metrics_to_heal):
                          sync_remain, sync_percent)
         print status_line
 
-        heal_metric(staging, local)
+        # Do not try healing data past the point they were rsync'd
+        # as we would not have new points in staging anyway.
+        heal_metric(staging, local, end_time=batch_start)
 
         sync_elapsed += time() - sync_start
         sync_avg = sync_elapsed / sync_count
@@ -66,11 +68,14 @@ def sync_batch(metrics_to_heal):
     return batch_elapsed
 
 
-def heal_metric(source, dest):
+def heal_metric(source, dest, start_time=0, end_time=None):
+    if end is None:
+        end = time()
     try:
         with open(dest):
             try:
-                fill_archives(source, dest, time())
+                # fill_archives' start and end are the opposite of what you'd expect
+                fill_archives(source, dest, startFrom=end_time, endAt=start_time)
             except CorruptWhisperFile as e:
                 logging.warn("Overwriting corrupt file %s!" % dest)
                 try:


### PR DESCRIPTION
This will be used to implement resuming heal.
As a minor optimisation, it also makes sync_batch heal only up to when it rsync'd.
